### PR TITLE
Feat/us14

### DIFF
--- a/app/controllers/admin/application_pets_controller.rb
+++ b/app/controllers/admin/application_pets_controller.rb
@@ -1,9 +1,7 @@
 class Admin::ApplicationPetsController < ApplicationController
 
   def update
-    # require 'pry'; binding.pry
-
-    application_pet = ApplicationPet.find_by(application_id: params[:application_id],pet_id: params[:pet_id])
+    application_pet = ApplicationPet.find_by(application_id: params[:application_id], pet_id: params[:pet_id])
     application_pet.update(status: params[:status])
     redirect_to "/admin/applications/#{params[:application_id]}"
   end

--- a/app/controllers/admin/applications_controller.rb
+++ b/app/controllers/admin/applications_controller.rb
@@ -1,6 +1,5 @@
 class Admin::ApplicationsController < ApplicationController
   def show 
     @application = Application.find(params[:id])
-    
   end
 end

--- a/app/models/pet.rb
+++ b/app/models/pet.rb
@@ -19,13 +19,13 @@ class Pet < ApplicationRecord
     Pet.where("name ILIKE ?", "%#{pet}%")
   end
 
-  def choice_made(application)
-    ApplicationPet.find_by(pet: self, application: application).status?
-  end
+  # def choice_made(application)
+  #   ApplicationPet.find_by(pet: self, application: application).status?
+  # end
 
-  def status(application)
-    ApplicationPet.find_by(pet: self, application: application).status
-  end
+  # def status(application)
+  #   ApplicationPet.find_by(pet: self, application: application).status
+  # end
 
 
 end

--- a/app/views/admin/applications/show.html.erb
+++ b/app/views/admin/applications/show.html.erb
@@ -9,24 +9,19 @@
 <%= @application.status%>
 
 
+<% @application.application_pets.each do |app_pet| %>
+<section id="Pet-<%= app_pet.pet_id %>">
+<%= app_pet.pet.name%>
 
-<% @application.pets.each do|pet|%>
-  <section id="Pet-<%= pet.id %>">
-    
-  
-    <%= pet.name%>
-    
-    <% if pet.choice_made(@application) %>
-      <%= pet.status(@application)%>
+<% if !app_pet.status.nil? %>
+  <p><%= app_pet.status %></p>
+<% else%>
+   <%= button_to "Approve #{app_pet.pet.name}", "/admin/applications/#{@application.id}/pets/#{app_pet.pet_id}?status=Approved", method: :patch %>
+    <%= button_to "Reject #{app_pet.pet.name}", "/admin/applications/#{@application.id}/pets/#{app_pet.pet_id}?status=Rejected", method: :patch %>
+<% end %>
 
-    <% else %>
-    
-      <%= button_to "Approve #{pet.name}", "/admin/applications/#{@application.id}/pets/#{pet.id}?status=Approved", method: :patch %>
-      <%= button_to "Reject #{pet.name}", "/admin/applications/#{@application.id}/pets/#{pet.id}?status=Rejected", method: :patch %>
-
-    <% end %>
-  </section>
-   
 <%end%>
+</section>
+
 
 

--- a/app/views/pets/_form.html.erb
+++ b/app/views/pets/_form.html.erb
@@ -1,0 +1,16 @@
+<$# locals: (path:, method:) - %>
+<%= form_with url: path, method: method, local: true do |f|%>
+    <%= f.label :name %>
+    <%= f.text_field :name %>
+
+    <%= f.label :breed %>
+    <%= f.text_field :breed %>
+
+    <%= f.label :age %>
+    <%= f.number_field :age %>
+
+    <%= f.label :adoptable %>
+    <%= f.check_box :adoptable, value: true %>
+
+    <%= f.submit %>
+<%end%>

--- a/app/views/pets/edit.html.erb
+++ b/app/views/pets/edit.html.erb
@@ -1,16 +1,6 @@
 <h1>Edit Pet</h1>
-<%= form_with url: "/pets/#{@pet.id}", method: :patch, local: true do |f| %>
-  <%= f.label :name %>
-  <%= f.text_field :name %>
 
-  <%= f.label :breed %>
-  <%= f.text_field :breed %>
-
-  <%= f.label :adoptable %>
-  <%= f.check_box :adoptable %>
-
-  <%= f.label :age %>
-  <%= f.number_field :age %>
-
-  <%= f.submit %>
-<% end %>
+<%= render partial: 'form', locals: { 
+  path: "/pets/#{@pet.id}", 
+  method: :patch
+  }%>

--- a/app/views/pets/new.html.erb
+++ b/app/views/pets/new.html.erb
@@ -1,16 +1,6 @@
 <h1>New Pet</h1>
-<%= form_with url: "/shelters/#{@shelter.id}/pets", method: :post, local: true do |f| %>
-  <%= f.label :name %>
-  <%= f.text_field :name %>
 
-  <%= f.label :breed %>
-  <%= f.text_field :breed %>
-
-  <%= f.label :age %>
-  <%= f.number_field :age %>
-
-  <%= f.label :adoptable %>
-  <%= f.check_box :adoptable, value: true %>
-
-  <%= f.submit %>
-<% end %>
+<%= render partial: 'form', locals: { 
+  path: "/shelters/#{@shelter.id}/pets", 
+  method: :post
+  }%>

--- a/spec/features/admin/applications/show_spec.rb
+++ b/spec/features/admin/applications/show_spec.rb
@@ -8,32 +8,41 @@ RSpec.describe "Admin application show page" do
         shelter_1 = Shelter.create(name: "Aurora shelter", city: "Aurora, CO", foster_program: false, rank: 9)
         shaggy = Application.create(name: "Shaggy", street_address: "123 Mystery Lane", city: "Irvine", state: "CA", zip_code: "91010", description: "Because ",status: "Pending")
         
-        @pet_1 = shelter_1.pets.create(name: "Mr. Pirate", breed: "tuxedo shorthair", age: 5, adoptable: false)
-        @pet_2 = shelter_1.pets.create(name: "Clawdia", breed: "shorthair", age: 3, adoptable: true )
-        @pet_3 = shelter_1.pets.create(name: "Ann", breed: "ragdoll", age: 5, adoptable: true)
+        pet_1 = shelter_1.pets.create(name: "Mr. Pirate", breed: "tuxedo shorthair", age: 5, adoptable: false)
+        pet_2 = shelter_1.pets.create(name: "Clawdia", breed: "shorthair", age: 3, adoptable: true )
+        pet_3 = shelter_1.pets.create(name: "Ann", breed: "ragdoll", age: 5, adoptable: true)
 
-        shaggy.pets << [@pet_1,@pet_2,@pet_3]
+        shaggy.pets << [pet_1,pet_2,pet_3]
 
         # When I visit an admin application show page ('/admin/applications/:id')
         visit "/admin/applications/#{shaggy.id}"
         # For every pet that the application is for, I see a button to approve the application for that specific pet
-        shaggy.pets.each do |pet|
-          expect(page).to have_button("Approve #{pet.name}")
+        within "#Pet-#{pet_1.id}" do
+            expect(page).to have_button("Approve #{pet_1.name}")
+        end
+        within "#Pet-#{pet_2.id}" do
+          expect(page).to have_button("Approve #{pet_2.name}")
         end
 
+        within "#Pet-#{pet_3.id}" do
+          expect(page).to have_button("Approve #{pet_3.name}")
+          click_button("Approve #{pet_3.name}")
+        end
         # When I click that button
-        click_button("Approve #{@pet_1.name}")
+        
 
         # Then I'm taken back to the admin application show page
         expect(current_path).to eq("/admin/applications/#{shaggy.id}")
 
         # And next to the pet that I approved, I do not see a button to approve this pet
-        expect(page).to_not have_button("Approve #{@pet_1.name}")
 
-        # And instead I see an indicator next to the pet that they have been approved
-       within "#Pet-#{@pet_1.id}" do 
-        expect(page).to have_content('Approved')
-       end
+        within "#Pet-#{pet_3.id}" do
+          expect(page).to_not have_button("Approve #{pet_3.name}")
+          expect(page).to_not have_button("Reject #{pet_3.name}")
+          # And instead I see an indicator next to the pet that they have been approved
+          expect(page).to have_content('Approved')
+        end
+        
       end
     end
   end
@@ -71,6 +80,46 @@ RSpec.describe "Admin application show page" do
         expect(page).to have_content('Rejected')
        end
       end
+    end
+  end
+
+  describe 'US 14' do
+    it 'does not affect pending apps when pet is approved/rejected' do
+
+      aurora_shelter = Shelter.create(name: "Aurora shelter", city: "Aurora, CO", foster_program: false, rank: 9)
+      rgv_shelter = Shelter.create(name: "RGV animal shelter", city: "Harlingen, TX", foster_program: false, rank: 5)
+
+      pet_1 = aurora_shelter.pets.create(name: "Mr. Pirate", breed: "tuxedo shorthair", age: 5, adoptable: false)
+      pet_2 = rgv_shelter.pets.create(name: "Clawdia", breed: "shorthair", age: 3, adoptable: true )
+      pet_3 = aurora_shelter.pets.create(name: "Ann", breed: "ragdoll", age: 5, adoptable: true)
+
+      martin = Application.create!(name: "Martin", street_address: "134 Huski Lane", city: "Chicago", state: "Ilinois", zip_code: 60609, description: "I love dogs", status: "Pending")
+      odell = Application.create!(name: "Odell", street_address: "145 Dog Lane", city: "Denver", state: "CO", zip_code: 60655, description: "Hi!", id: 1)
+
+      odell.pets << [pet_1, pet_2]
+      martin.pets << [pet_3, pet_2]
+      
+      # 14. Approved/Rejected Pets on one Application do not affect other Applications
+
+      # As a visitor
+      # When there are two applications in the system for the same pet
+      # When I visit the admin application show page for one of the applications
+      visit "/admin/applications/#{odell.id}"
+      # And I approve or reject the pet for that application
+      click_button("Approve Clawdia")
+      # When I visit the other application's admin show page
+      visit "/admin/applications/#{martin.id}"
+      # Then I do not see that the pet has been accepted or rejected for that application
+      within "#Pet-#{pet_2.id}" do 
+        expect(page).to_not have_content('Rejected')
+        expect(page).to_not have_content('Accepted')
+       end
+      # And instead I see buttons to approve or reject the pet for this specific application
+      within "#Pet-#{pet_2.id}" do 
+        expect(page).to have_button("Approve Clawdia")
+        expect(page).to have_button("Reject Clawdia")
+       end
+      
     end
   end
   

--- a/spec/models/pet_spec.rb
+++ b/spec/models/pet_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Pet, type: :model do
   end
 
   describe '#status' do
-    it 'returns the status of of a pet on an application' do
+    xit 'returns the status of of a pet on an application' do
       ApplicationPet.create!(pet: @pet_2, application: @applicant1, status:"Approved")
       ApplicationPet.create!(pet: @pet_1, application: @applicant1, status:"Rejected")
       ApplicationPet.create!(pet: @pet_3, application: @applicant1)
@@ -32,7 +32,7 @@ RSpec.describe Pet, type: :model do
   end
 
   describe '#choice_made' do
-    it 'checks if pet is rejected or approved on an application' do
+    xit 'checks if pet is rejected or approved on an application' do
       ApplicationPet.create!(pet: @pet_2, application: @applicant1, status:"Approved")
       ApplicationPet.create!(pet: @pet_1, application: @applicant1, status:"Rejected")
       ApplicationPet.create!(pet: @pet_3, application: @applicant1)


### PR DESCRIPTION
Lets review these changes together before merging

- Changed the logic within the admin applications show page view to utilize an ApplicationPet object to retrieve what we need.
- Changes above cause us not to need a couple of methods in the pet model (ie. change_made and status) 
- Created partials for the forms used to create and update a pet

_14. Approved/Rejected Pets on one Application do not affect other Applications

As a visitor
When there are two applications in the system for the same pet
When I visit the admin application show page for one of the applications
And I approve or reject the pet for that application
When I visit the other application's admin show page
Then I do not see that the pet has been accepted or rejected for that application
And instead I see buttons to approve or reject the pet for this specific application_